### PR TITLE
fix(run): remove redundant relative path prefix when executing scripts

### DIFF
--- a/run
+++ b/run
@@ -64,6 +64,6 @@ for script in $scripts; do
         continue
     fi
     log "running script: $script"
-    execute ./$script
+    execute "$script"
 done
 


### PR DESCRIPTION
Fixes a minor issue in the run orchestrator where scripts were executed using `./$script`, which resulted in evaluating to a redundant path prefix like `././runs/<tool>` instead of `./runs/<tool>`.