### PR TITLE
Add super+shift+e keybind for new split down

### DIFF
--- a/.config/ghostty
+++ b/.config/ghostty
@@ -55,3 +55,4 @@ keybind = super+shift+k=goto_split:up
 keybind = super+shift+j=goto_split:down
 keybind = super+shift+r=reload_config
 keybind = super+shift+enter=toggle_split_zoom
+keybind = super+shift+e=new_split:down


### PR DESCRIPTION
Adds keybinding `super+shift+e` mapped to `new_split:down` (replaces default ctrl+shift+e).