### PR TITLE
refactor(gitconfig): one identity per machine, rendered from a template

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@ Personal developer environment setup repository — a collection of bash install
 ./run <tool>       # Run a specific installer (e.g., ./run docker)
 ./run --dry <tool> # Dry-run to preview which scripts would execute
 ./dev              # Copy dotfiles and configs to system directories (~/.config/, ~/.local/, etc.)
-./gitconfig        # Interactive setup for dual personal/work Git profiles with separate SSH keys
+./gitconfig        # Set up this machine's Git identity and SSH key (one identity per machine)
 ```
 
 There is no build system, test suite, or linter.
@@ -23,7 +23,7 @@ There is no build system, test suite, or linter.
 - **`run`** — Main orchestrator. Discovers and sequentially executes all executable files in `runs/`. Accepts an optional filter argument to match specific scripts.
 - **`runs/`** — ~38 standalone bash installer scripts, each named after the tool they install (e.g., `runs/docker`, `runs/go`, `runs/neovim`). Scripts are independent with no inter-dependencies.
 - **`dev`** — Copies config directories from `.config/` and `.local/` plus shell dotfiles (`.bash_aliases`, `.bash_profile`) to the user's home directory.
-- **`gitconfig`** — Interactive script that sets up conditional git includes and separate SSH keys for personal vs. work directories.
+- **`gitconfig`** — Configures the machine's single Git identity and SSH key. Values resolve from environment variable, then the previous run's cache, then an interactive prompt, and are rendered from `templates/`.
 
 ### Dotfiles / Configuration
 

--- a/gitconfig
+++ b/gitconfig
@@ -1,99 +1,190 @@
 #!/usr/bin/env bash
+set -euo pipefail
 
-profiles=("personal" "work")
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+templates_dir="$script_dir/templates"
 
-check_ssh() {
-    local profile_name=$1
+config_dir="${XDG_CONFIG_HOME:-$HOME/.config}"
+cache_file="$config_dir/run/gitconfig.env"
 
-    local exists=1
-    if [[ -f "$HOME/.ssh/$profile_name" ]]; then
-        exists=0
-    fi
+begin_marker="# >>> managed by run/gitconfig >>>"
+end_marker="# <<< managed by run/gitconfig <<<"
 
-    return $exists
+declare -A cached
+
+die() {
+    echo "gitconfig: $*" >&2
+    exit 1
 }
 
-check_config() {
-    local profile_name=$1
+usage() {
+    cat <<EOF
+Usage: ./gitconfig
 
-    exists=1
-    if [[ -f "$HOME/.config/git/$profile_name.config" ]]; then
-        exists=0
-    fi
+Configures the git identity and SSH key for this machine. One identity per
+machine: values are resolved from the environment, then from the previous
+run ($cache_file), then by prompting.
 
-    return $exists
-}
+Environment variables:
+  GIT_NAME      name recorded on commits
+  GIT_EMAIL     email recorded on commits
+  GITHUB_USER   github.com account the key is added to
+  SSH_KEY       key name under ~/.ssh (default: github)
 
-create_config_file() {
-    local profile=$1
-    local email=$2
-
-    cat <<EOF > "$HOME/.config/git/$profile.config"
-[user]
-    name = Erik Røed
-    email = $email
-    signingkey = $HOME/.ssh/$profile.pub
-
-[core]
-    sshCommand = "ssh -i $HOME/.ssh/$profile"
+Set all four to run unattended.
 EOF
 }
 
-update_git_root_config() {
-    cat <<EOF > "$HOME/.gitconfig"
-[core]
-    editor = vim
+load_cache() {
+    [[ -r $cache_file ]] || return 0
 
-[gpg]
-	format = ssh
+    local line key value
+    while IFS= read -r line; do
+        [[ $line == *=* ]] || continue
+        key=${line%%=*}
+        value=${line#*=}
+        value=${value#\"}
+        value=${value%\"}
+        cached[$key]=$value
+    done < "$cache_file"
+}
 
-[commit]
-	gpgsign = true
+resolve() {
+    local var=$1 prompt=$2 fallback=${3:-}
+    local default answer
 
-[includeIf "gitdir:~/code/personal/"]
-    path = ~/.config/git/personal.config
+    [[ -z ${!var:-} ]] || return 0
 
-[includeIf "gitdir:~/code/work/"]
-    path = ~/.config/git/work.config
+    default=${cached[$var]:-$fallback}
+
+    if [[ ! -t 0 ]]; then
+        [[ -n $default ]] || die "$var is unset and has no cached value; export it to run unattended"
+        printf -v "$var" '%s' "$default"
+        return 0
+    fi
+
+    if [[ -n $default ]]; then
+        read -r -p "$prompt [$default]: " answer
+    else
+        read -r -p "$prompt: " answer
+    fi
+
+    printf -v "$var" '%s' "${answer:-$default}"
+    [[ -n ${!var} ]] || die "$var must not be empty"
+}
+
+render() {
+    local template=$1
+    local line var value placeholder
+
+    [[ -f $template ]] || die "template not found: $template"
+
+    while IFS= read -r line || [[ -n $line ]]; do
+        while [[ $line =~ \{\{[[:space:]]*([A-Za-z_][A-Za-z0-9_]*)[[:space:]]*\}\} ]]; do
+            placeholder=${BASH_REMATCH[0]}
+            var=${BASH_REMATCH[1]}
+            value=${!var:-}
+            [[ -n $value ]] || die "$template references $var, which is not set"
+            line=${line//"$placeholder"/$value}
+        done
+        printf '%s\n' "$line"
+    done < "$template"
+}
+
+replace_managed_block() {
+    local file=$1 position=$2
+    local block rest tmp
+
+    block=$(cat)
+    mkdir -p "$(dirname "$file")"
+    [[ -f $file ]] || touch "$file"
+
+    rest=$(awk -v b="$begin_marker" -v e="$end_marker" '
+        $0 == b { skip = 1; next }
+        $0 == e { skip = 0; next }
+        !skip
+    ' "$file")
+
+    tmp=$(mktemp)
+    if [[ $position == "prepend" ]]; then
+        printf '%s\n%s\n%s\n\n%s\n' "$begin_marker" "$block" "$end_marker" "$rest" > "$tmp"
+    else
+        printf '%s\n\n%s\n%s\n%s\n' "$rest" "$begin_marker" "$block" "$end_marker" > "$tmp"
+    fi
+
+    awk 'NF == 0 { blank = 1; next } { if (blank && seen) print ""; blank = 0; seen = 1; print }' "$tmp" > "$file"
+    rm -f "$tmp"
+}
+
+ensure_ssh_key() {
+    mkdir -p "$HOME/.ssh"
+    chmod 700 "$HOME/.ssh"
+
+    if [[ -f $SSH_KEY_PATH ]]; then
+        echo "ssh key $SSH_KEY_PATH already exists"
+        return 0
+    fi
+
+    echo "generating ssh key $SSH_KEY_PATH"
+    ssh-keygen -t ed25519 -C "$GIT_EMAIL" -f "$SSH_KEY_PATH" -N ""
+}
+
+write_git_config() {
+    local content
+    content=$(render "$templates_dir/gitconfig.tmpl")
+
+    replace_managed_block "$HOME/.gitconfig" append <<<"$content"
+}
+
+write_ssh_config() {
+    local content
+    content=$(render "$templates_dir/ssh_config.tmpl")
+
+    replace_managed_block "$HOME/.ssh/config" prepend <<<"$content"
+    chmod 600 "$HOME/.ssh/config"
+}
+
+persist_cache() {
+    mkdir -p "$(dirname "$cache_file")"
+    cat > "$cache_file" <<EOF
+GIT_NAME="$GIT_NAME"
+GIT_EMAIL="$GIT_EMAIL"
+GITHUB_USER="$GITHUB_USER"
+SSH_KEY="$SSH_KEY"
 EOF
 }
 
-run() {
-    echo "This script will generate ssh-keys and gitconfig for personal and work profile if they don't already exists..."
+main() {
+    case "${1:-}" in
+        -h|--help) usage; exit 0 ;;
+        "") ;;
+        *) usage >&2; die "unexpected argument '$1'" ;;
+    esac
 
-    read -p "Enter y to continue: " confirmation
+    load_cache
 
-    if [[ $confirmation != "y" ]]; then
-        echo "Stopping...."
-        exit 1;
-    fi
+    resolve GIT_NAME "Name for commits" "$(git config --global user.name || true)"
+    resolve GIT_EMAIL "Email for commits" "$(git config --global user.email || true)"
+    resolve GITHUB_USER "GitHub username"
+    resolve SSH_KEY "SSH key name under ~/.ssh" "github"
 
-    if [[ ! -d $HOME/.config/git/ ]]; then
-        mkdir -p $HOME/.config/git
-    fi
+    SSH_KEY_PATH="$HOME/.ssh/$SSH_KEY"
+    SSH_PUBLIC_KEY="$SSH_KEY_PATH.pub"
 
-    for profile in "${profiles[@]}"; do
-        read -p "Enter email for $profile: " email
+    echo "configuring git for $GIT_NAME <$GIT_EMAIL>"
 
-        check_ssh $profile
-        if [[ $? -eq 1 ]]; then
-            echo "ssh-key not found... generating..."
-            ssh-keygen -t ed25519 -C "$email" -f $HOME/.ssh/$profile
-            eval "$(ssh-agent -s)"
-            ssh-add $HOME/.ssh/$profile
-        fi
+    ensure_ssh_key
+    write_git_config
+    write_ssh_config
+    persist_cache
 
-        check_config $profile
-        if [[ $? -eq 1 ]]; then
-            echo "gitconfig not found for $profile... generating file..."
-            create_config_file $profile $email
-        fi
-    done 
-
-    echo "Replacing ~/.gitconfig with new settings"
-    update_git_root_config
-
-    echo "Git is now configured with separate ssh-keys and configs for private and work"
+    echo
+    echo "public key:"
+    cat "$SSH_PUBLIC_KEY"
+    echo
+    echo "add it to github.com/$GITHUB_USER as both an authentication and a signing key:"
+    echo "  gh ssh-key add $SSH_PUBLIC_KEY --type authentication"
+    echo "  gh ssh-key add $SSH_PUBLIC_KEY --type signing"
 }
 
-run
+main "$@"

--- a/templates/gitconfig.tmpl
+++ b/templates/gitconfig.tmpl
@@ -1,0 +1,13 @@
+[user]
+    name = {{ GIT_NAME }}
+    email = {{ GIT_EMAIL }}
+    signingkey = {{ SSH_PUBLIC_KEY }}
+
+[gpg]
+    format = ssh
+
+[commit]
+    gpgsign = true
+
+[core]
+    editor = vim

--- a/templates/ssh_config.tmpl
+++ b/templates/ssh_config.tmpl
@@ -1,0 +1,6 @@
+Host github.com
+    HostName github.com
+    User git
+    IdentityFile {{ SSH_KEY_PATH }}
+    IdentitiesOnly yes
+    AddKeysToAgent yes


### PR DESCRIPTION
Closes #18.

v1's `gitconfig` assumed one machine hosts two identities: it looped over a
hardcoded `profiles=("personal" "work")` array, prompted for both emails,
generated both keypairs, and wrote both `includeIf` blocks even on a machine
that only needed one. From v2 there is one identity per machine, so `includeIf`,
the per-profile config files and `core.sshCommand` all go.

## Values

Resolved in this order, so the script works by hand today and unattended under
Ansible later:

1. environment variable — `GIT_NAME`, `GIT_EMAIL`, `GITHUB_USER`, `SSH_KEY`
2. cached answer from the previous run, in `$XDG_CONFIG_HOME/run/gitconfig.env`
3. interactive prompt, showing the cached or fallback value as the default

`SSH_KEY` is the key name under `~/.ssh` (default `github`), configurable rather
than fixed.

## Generation

Output is rendered from `templates/`, not emitted as heredocs. Both templates
use plain `{{ var }}` substitution with no conditionals, loops or filters, so
Ansible's `template` module or Go's `text/template` can render the same files
unchanged. All logic stays in the script.

- global git config: `user.name`, `user.email`, `user.signingkey`,
  `gpg.format = ssh`, `commit.gpgsign`, `core.editor`
- ed25519 keypair at the chosen name, generated only if missing
- a `Host github.com` block in `~/.ssh/config`, written unconditionally — a
  non-default key name means ssh would not otherwise find the key

Both files are spliced between managed markers, so unrelated settings survive.
The ssh block is prepended because `ssh_config` is first-match-wins per keyword;
the git block is appended because git takes the last value.

This also fixes v1's latent bug where `commit.gpgsign` was set globally while
`user.signingkey` only existed inside the `includeIf`, so any commit made
outside `~/code/<profile>/` was configured to sign with no key available.

## Reused from `refactor/gitconfig-profiles`

`replace_managed_block`, `ensure_ssh_key` and the `Host github.com` block carry
over. Everything profile-shaped is dropped: `profiles/`, `includeIf`, the
per-profile config files, `core.sshCommand`, and the
`.bash_aliases.personal/.work` split. The ssh-agent user service and the
`.bash_profile` key loading from that branch are deliberately left out — they
belong to #20 — so `.bash_profile` and `.bash_aliases` are untouched here.

## Verification

Exercised in sandboxed `HOME` directories, never against a real config.

| Acceptance criterion | Result |
| --- | --- |
| Fresh machine prompts and produces a working setup | Interactive run over a pty; key generated, defaults accepted |
| Re-running is idempotent and does not clobber unrelated settings | Byte-identical re-run; a pre-existing `[alias]` and `Host myserver` both survive |
| Every value can be supplied by environment variable | Ran with stdin closed; a missing value fails with a clear message rather than hanging |
| No `includeIf`, no per-profile config files, no `core.sshCommand` | Absent from the output |
| Signing works in every repository | `commit.gpgsign` and `user.signingkey` are both global |

One bug was found and fixed during testing: `render | replace_managed_block`
wrote the destination before the pipeline's failure status was known, so a
template referencing an unset variable left a truncated section in
`~/.gitconfig`. It now renders to a variable first, and a failing template
leaves the file byte-identical.

## Notes

On a machine still carrying v1's `~/.gitconfig`, the old `includeIf` blocks are
not removed. The new managed block is appended after them so it wins, and the
existing configs will be cleaned up and regenerated by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)