### PR TITLE
refactor(aliases): guard tool-dependent aliases and drop the dev alias

### DIFF
--- a/.bash_aliases
+++ b/.bash_aliases
@@ -1,12 +1,11 @@
-alias vim='nvim'
+command -v nvim > /dev/null && alias vim='nvim'
 alias bc='vim ~/.bashrc'
 alias bca='vim ~/.bash_aliases'
 alias sbc='source ~/.bashrc'
 alias tns='tmux new-session -s'
-alias dev='ssh roed@dev'
 alias lg='lazygit'
-alias fd='fdfind'
-alias cat='batcat'
+command -v fdfind > /dev/null && alias fd='fdfind'
+command -v batcat > /dev/null && alias cat='batcat'
 
 alias k=kubectl
 complete -o default -F __start_kubectl k


### PR DESCRIPTION
Closes #19.

## Guarded aliases

`alias cat='batcat'` **shadowed coreutils `cat`**, so on a machine without bat
every interactive `cat` failed with `batcat: command not found`. `alias
vim='nvim'` had the same shape and was arguably worse — it broke a working
`vim` wherever neovim was absent. Both, plus `fd` → `fdfind`, now define only
when the tool actually resolves:

```bash
command -v nvim   > /dev/null && alias vim='nvim'
command -v fdfind > /dev/null && alias fd='fdfind'
command -v batcat > /dev/null && alias cat='batcat'
```

The check runs when the file is sourced, so a tool installed mid-session shows
up in the next shell, or immediately after `sbc`.

This also softens the Ubuntu package-naming problem the issue raises: on a
distro without `batcat`/`fdfind`, the aliases are simply absent rather than
broken.

`lg` stays unguarded on purpose — lazygit is always installed, and `lg` shadows
nothing, so a dangling alias would only ever bite when used.

### Why not put these in the installers

The tempting alternative is having `runs/bat` add its own alias. It does not
work here: `dev` does `rm ~/.bash_aliases; cp .bash_aliases ~/`, replacing the
file wholesale, so anything an installer appended would be destroyed by the
next `./dev` — and since `./run` and `./dev` are separate entry points,
whichever ran last would decide whether the alias survived. Making it work
would need a `~/.bash_aliases.d/` drop-in directory plus a sourcing loop, which
splits the aliases across two places and costs `bca` its property of showing
you everything.

## Removed

`alias dev='ssh roed@dev'` — a no-op on the dev machine itself, and it collides
by name with this repo's own `./dev` script.

## Kept

The `k` / kubectl completion block. It is homelab tooling, alongside `talosctl`,
`flux`, `helm`, `k9s` and `kubectx` in `runs/`, so it is personal and stays.

## Verification

Tested in a clean room — `env -i PATH=<stripped> bash --norc --noprofile` —
because an interactive shell sources the already-deployed `~/.bash_aliases` and
masks the result.

| Case | Result |
| --- | --- |
| Tools absent | `vim`, `fd`, `cat` undefined; real `cat` works normally |
| Tools present | All three defined as before |
| Installed mid-session | Not picked up until the next shell or `sbc` |
| `source` exit status | 0 in both cases, so `sbc` shows no spurious failure |

## Notes

Nothing left in the file is machine-specific, so the untracked
`~/.bash_aliases.local` the issue floated is not needed. The second acceptance
criterion is satisfied by there being nothing to put there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)