### PR TITLE
feat(gitconfig): persist ssh-agent via a systemd user service

### DIFF
--- a/.bash_profile
+++ b/.bash_profile
@@ -31,3 +31,18 @@ if [ -d "$HOME/.local/scripts" ]; then
     PATH="$HOME/.local/scripts:$PATH"
 fi
 
+__ssh_agent_socket="${XDG_RUNTIME_DIR:-/run/user/$(id -u)}/ssh-agent.socket"
+if [ -S "$__ssh_agent_socket" ]; then
+    export SSH_AUTH_SOCK="$__ssh_agent_socket"
+
+    if ! ssh-add -l > /dev/null 2>&1; then
+        __gitconfig_env="${XDG_CONFIG_HOME:-$HOME/.config}/run/gitconfig.env"
+        if [ -r "$__gitconfig_env" ]; then
+            __ssh_key="$HOME/.ssh/$(. "$__gitconfig_env"; echo "$SSH_KEY")"
+            [ -f "$__ssh_key" ] && ssh-add -q "$__ssh_key"
+            unset __ssh_key
+        fi
+        unset __gitconfig_env
+    fi
+fi
+unset __ssh_agent_socket

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,7 @@ There is no build system, test suite, or linter.
 - **`run`** — Main orchestrator. Discovers and sequentially executes all executable files in `runs/`. Accepts an optional filter argument to match specific scripts.
 - **`runs/`** — ~38 standalone bash installer scripts, each named after the tool they install (e.g., `runs/docker`, `runs/go`, `runs/neovim`). Scripts are independent with no inter-dependencies.
 - **`dev`** — Copies config directories from `.config/` and `.local/` plus shell dotfiles (`.bash_aliases`, `.bash_profile`) to the user's home directory.
-- **`gitconfig`** — Configures the machine's single Git identity and SSH key. Values resolve from environment variable, then the previous run's cache, then an interactive prompt, and are rendered from `templates/`.
+- **`gitconfig`** — Configures the machine's single Git identity and SSH key, and installs the ssh-agent systemd user service. Values resolve from environment variable, then the previous run's cache, then an interactive prompt, and are rendered from `templates/`.
 
 ### Dotfiles / Configuration
 

--- a/gitconfig
+++ b/gitconfig
@@ -144,6 +144,46 @@ write_ssh_config() {
     chmod 600 "$HOME/.ssh/config"
 }
 
+setup_ssh_agent() {
+    local unit_dir content
+
+    if ! command -v systemctl > /dev/null || ! command -v ssh-agent > /dev/null; then
+        echo "systemd or ssh-agent not available; skipping the agent service" >&2
+        return 0
+    fi
+
+    SSH_AGENT=$(command -v ssh-agent)
+    unit_dir="$config_dir/systemd/user"
+    content=$(render "$templates_dir/ssh-agent.service.tmpl")
+
+    mkdir -p "$unit_dir"
+    printf '%s\n' "$content" > "$unit_dir/ssh-agent.service"
+
+    if ! systemctl --user daemon-reload 2> /dev/null; then
+        echo "no systemd user session; the agent service is installed but not started" >&2
+        return 0
+    fi
+
+    loginctl enable-linger "$USER" 2> /dev/null || sudo loginctl enable-linger "$USER"
+    systemctl --user enable --now ssh-agent.service
+
+    export SSH_AUTH_SOCK="${XDG_RUNTIME_DIR:-/run/user/$(id -u)}/ssh-agent.socket"
+    load_ssh_key
+}
+
+load_ssh_key() {
+    local fingerprint
+
+    fingerprint=$(ssh-keygen -lf "$SSH_PUBLIC_KEY" | awk '{print $2}')
+
+    if ssh-add -l 2> /dev/null | grep -qF "$fingerprint"; then
+        echo "key already loaded in the agent"
+        return 0
+    fi
+
+    ssh-add "$SSH_KEY_PATH"
+}
+
 persist_cache() {
     mkdir -p "$(dirname "$cache_file")"
     cat > "$cache_file" <<EOF
@@ -176,6 +216,7 @@ main() {
     ensure_ssh_key
     write_git_config
     write_ssh_config
+    setup_ssh_agent
     persist_cache
 
     echo

--- a/templates/ssh-agent.service.tmpl
+++ b/templates/ssh-agent.service.tmpl
@@ -1,0 +1,10 @@
+[Unit]
+Description=SSH key agent
+
+[Service]
+Type=simple
+Environment=SSH_AUTH_SOCK=%t/ssh-agent.socket
+ExecStart={{ SSH_AGENT }} -D -a $SSH_AUTH_SOCK
+
+[Install]
+WantedBy=default.target


### PR DESCRIPTION
Closes #20.

v1 ran `eval "$(ssh-agent -s)"` inside the script's own shell, and only in the
branch where a key had just been generated. The agent died with the script, so
every ssh login still needed `ssh-agent` and `ssh-add` by hand.

## Approach

A systemd **user** service owns a single agent, shared by every shell and ssh
login on the machine.

- the unit is rendered from `templates/ssh-agent.service.tmpl`, like the other
  generated files, with the `ssh-agent` path substituted in
- `loginctl enable-linger` brings the agent up after boot without waiting for an
  interactive login
- `.bash_profile` exports `SSH_AUTH_SOCK` and loads the key **only** when
  `ssh-add -l` reports the agent empty — it survives reboot but starts with no
  identities
- the key name comes from `$XDG_CONFIG_HOME/run/gitconfig.env`, the cache
  `gitconfig` already writes, so there is one source of truth for it
- `AddKeysToAgent yes` was already in the `~/.ssh/config` block from #18 and now
  has an agent to talk to

## Verification

Driven with stubbed `systemctl`, `loginctl` and `ssh-add` against sandboxed
`HOME` directories, so nothing touched a real session.

| Acceptance criterion | Result |
| --- | --- |
| Agent running with the key loaded | Unit rendered with the real `ssh-agent` path; `%t` and `$SSH_AUTH_SOCK` survive templating; calls issued in order: `daemon-reload`, `enable-linger`, `enable --now`, `ssh-add -l`, `ssh-add <key>` |
| Re-running does not add the key twice | Second run reports "key already loaded in the agent"; no `ssh-add <key>` call, agent still holds exactly 1 identity |
| Degrades gracefully without systemd | `systemctl` absent: service skipped, no unit written, and git config, key and ssh config are all still produced. No user session: unit written, not started, script continues |

`.bash_profile` was exercised separately against a real unix socket:

| Case | Result |
| --- | --- |
| No socket | `SSH_AUTH_SOCK` unset, no `ssh-add` call |
| Socket present, agent empty | Socket exported, `ssh-add -q ~/.ssh/<key>` with the path derived from the cached name |
| Socket present, key already loaded | Socket exported, `ssh-add -l` only, no re-add |

Reboot survival is the one criterion a stub cannot demonstrate; the issue records
it as already verified end to end in a container running real systemd.

## Notes

This is the first PR to run the review workflow with the #26 fixes on `main`, so
its run also shows whether `permission_denials_count` drops to 0 and what the
Step Summary report looks like.

🤖 Generated with [Claude Code](https://claude.com/claude-code)