### PR TITLE
fix(ci): give the review agents the tools they need to post

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -39,7 +39,12 @@ jobs:
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
-          claude_args: '--allowedTools "Bash(git log:*)" "Bash(git blame:*)" "Bash(git show:*)"'
+          claude_args: >-
+            --allowedTools
+            "Bash(git log:*)" "Bash(git blame:*)" "Bash(git show:*)" "Bash(git diff:*)"
+            "Bash(gh pr view:*)" "Bash(gh pr diff:*)" "Bash(gh pr list:*)" "Bash(gh pr comment:*)"
+            "Bash(gh issue view:*)" "Bash(gh issue list:*)" "Bash(gh search:*)" "Bash(gh api:*)"
+            "Read" "Grep" "Glob" "Task"
           display_report: true
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options


### PR DESCRIPTION
The Claude Code Review workflow has never posted a review comment on any PR in this repo — #25, #26 and #28 all have zero. The runs report `success`, which is what makes it look like a hang rather than a failure.

## Cause

`claude_args: --allowedTools` **replaces** the tool set rather than adding to it. The SDK options in [run 32394401103](https://github.com/erikroed/run/actions/runs/32394401103) list only the three git patterns:

```
"allowedTools": [ "Bash(git log:*)", "Bash(git blame:*)", "Bash(git show:*)" ]
```

Every `gh` command in the plugin command's own frontmatter was therefore denied, along with `Read`, `Grep` and `Glob`. Since the plugin's final step is `gh pr comment`, the review ran to completion and then had no way to publish what it found. That run ended with `permission_denials_count: 18` and `No buffered inline comments`.

4730eb1 fixed the git half of this and narrowed everything else in the same stroke.

## Not the cause

The job's `permissions:` block is deliberately untouched. The action requests an OIDC token, exchanges it for a Claude GitHub App installation token, and overrides `GITHUB_TOKEN` with it:

```
Requesting OIDC token... → Exchanging OIDC token for app token...
App token successfully obtained → Using GITHUB_TOKEN from OIDC
```

So posting never depended on the workflow token, and widening `pull-requests` to `write` would have been an unnecessary permission grant.

## Testing

This PR is its own test case — the workflow runs against the diff that changes it. Two caveats when reading the result: the plugin skips PRs it judges trivial, and it deliberately posts nothing when no finding clears its 80-confidence threshold. A silent run is therefore not proof of failure; the job summary (`display_report: true`) shows what the reviewer actually found either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)