### PR TITLE
fix(runs/go): make repeated runs idempotent

### DIFF
--- a/runs/go
+++ b/runs/go
@@ -3,13 +3,19 @@
 VERSION=1.26.2
 
 wget https://go.dev/dl/go$VERSION.linux-amd64.tar.gz
+sudo rm -rf /usr/local/go
 sudo tar -C /usr/local -xzf go$VERSION.linux-amd64.tar.gz
 
 rm go$VERSION.linux-amd64.tar.gz
 
-echo -e "\nPATH=\"\$PATH:/usr/local/go/bin\"" >> ~/.bashrc
+if ! grep -q '/usr/local/go/bin' ~/.bashrc; then
+    echo -e "\nPATH=\"\$PATH:/usr/local/go/bin\"" >> ~/.bashrc
+fi
 
-export PATH=$PATH:/usr/local/go/bin
+case ":$PATH:" in
+    *:"/usr/local/go/bin":*) ;;
+    *) export PATH="$PATH:/usr/local/go/bin" ;;
+esac
 
 # Install debugger
 go install github.com/go-delve/delve/cmd/dlv@latest


### PR DESCRIPTION
`./run` with no arguments executes every script in `runs/`, so these scripts get re-run routinely. Two things in `runs/go` assumed a single run.

## `~/.bashrc` grew a new PATH line every time

```bash
echo -e "\nPATH=\"\$PATH:/usr/local/go/bin\"" >> ~/.bashrc
```

Unconditional append. This is the same duplication that had accumulated in `.bash_profile` (where `~/.local/bin` had stacked up three times), and it takes the same fix: guard the append, and use the established `case ":$PATH:"` idiom for the in-session export.

Verified idempotent — three consecutive runs against a scratch rc file leave one line, and the PATH guard leaves one entry.

## Unpacking over an existing install

```bash
sudo tar -C /usr/local -xzf go$VERSION.linux-amd64.tar.gz
```

Go's [install instructions](https://go.dev/doc/install) remove `/usr/local/go` first, because unpacking a new version over an old one leaves the old version's files behind. Added the `rm -rf` ahead of the extract.

## Note

This PR also serves as the first real test of the review workflow fixed in #29 — that fix could not be validated on its own PR, since the action skips any PR that modifies the workflow file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)