### PR TITLE
fix(runs): correctness fixes across the installer scripts

### DIFF
--- a/run
+++ b/run
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 
-script_dir="$(cd $(dirname "$BASH_SOURCE[0]}") && pwd)"
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 filters=()
 dry="0"
 
-cd $script_dir
+cd "$script_dir"
 scripts=$(find ./runs -maxdepth 1 -mindepth 1 -executable -type f)
 
 while [[ $# > 0 ]]; do

--- a/runs/aws
+++ b/runs/aws
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 # aws cli
-curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+curl -f "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
 unzip -o awscliv2.zip
 sudo ./aws/install --update
 
@@ -12,8 +12,8 @@ rm -rf awscliv2.zip aws/
 ARCH=amd64
 PLATFORM=$(uname -s)_$ARCH
 
-curl -sLO "https://github.com/eksctl-io/eksctl/releases/latest/download/eksctl_$PLATFORM.tar.gz"
-curl -sL "https://github.com/eksctl-io/eksctl/releases/latest/download/eksctl_checksums.txt" | grep $PLATFORM | sha256sum --check
+curl -fsLO "https://github.com/eksctl-io/eksctl/releases/latest/download/eksctl_$PLATFORM.tar.gz"
+curl -fsL "https://github.com/eksctl-io/eksctl/releases/latest/download/eksctl_checksums.txt" | grep $PLATFORM | sha256sum --check
 
 tar -xzf eksctl_$PLATFORM.tar.gz -C /tmp && rm eksctl_$PLATFORM.tar.gz
 

--- a/runs/aws
+++ b/runs/aws
@@ -1,9 +1,10 @@
 #!/usr/bin/env bash
+set -euo pipefail
 
 # aws cli
 curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
-unzip awscliv2.zip
-sudo ./aws/install
+unzip -o awscliv2.zip
+sudo ./aws/install --update
 
 rm -rf awscliv2.zip aws/
 

--- a/runs/docker
+++ b/runs/docker
@@ -16,7 +16,7 @@ sudo apt-get update
 
 sudo apt-get install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
 
-sudo groupadd docker
+getent group docker >/dev/null || sudo groupadd docker
 sudo usermod -aG docker $USER
 
 echo "Run: newgrp docker"

--- a/runs/emoji-fonts
+++ b/runs/emoji-fonts
@@ -1,1 +1,3 @@
+#!/usr/bin/env bash
+
 sudo apt install fonts-noto-color-emoji


### PR DESCRIPTION
Four independent fixes found while looking through `runs/`, one per commit so they can be reverted separately.

## `runs/aws` — a failed checksum did not stop the install

The most serious of the four. The script verified eksctl's checksum and then discarded the result:

```bash
curl -sL .../eksctl_checksums.txt | grep $PLATFORM | sha256sum --check

tar -xzf eksctl_$PLATFORM.tar.gz -C /tmp && rm eksctl_$PLATFORM.tar.gz
sudo install -m 0755 /tmp/eksctl /usr/local/bin
```

With no `set -e`, a mismatch printed a warning and the script installed the binary anyway — the verification was decorative. `set -euo pipefail` makes it binding. `pipefail` matters specifically because `sha256sum` is the last stage of a pipe: without it, a failure of the `curl` fetching the checksum list would also pass silently.

Verified both directions: a mismatched digest now exits 1 before the install step, a matching one proceeds.

The `unzip -o` and `install --update` changes are coupled to this, not cosmetic. Now that failures are fatal, a second run would otherwise break — `./aws/install` exits non-zero when the CLI is already present, and `unzip` prompts for overwrite confirmation when it finds a previously extracted `aws/`, which under `set -e` hangs rather than fails.

## `run` — silent no-op when the repo path contains a space

```bash
script_dir="$(cd $(dirname "$BASH_SOURCE[0]}") && pwd)"
```

The malformed `$BASH_SOURCE[0]}` (missing opening brace) is actually harmless — `$BASH_SOURCE` expands to the script path and the stray `[0]}` lands on the filename, which `dirname` strips. The missing quotes are the real bug. Reproduced with the repo under `a b/`:

```
line 2: cd: too many arguments
got=[]
```

`script_dir` ends up empty, the later bare `cd $script_dir` goes to `$HOME`, `find ./runs` matches nothing, and `./run` exits 0 having done nothing. Now works from a spaced path.

## `runs/emoji-fonts` — no shebang

The file began directly with the `apt` call, so `execve` returned ENOEXEC and the interpreter was whatever the caller fell back to rather than the one the file asks for. CLAUDE.md requires `#!/usr/bin/env bash`.

## `runs/docker` — `groupadd` on an existing group

`docker-ce` already creates the `docker` group, so `sudo groupadd docker` failed on every run after the first. Harmless noise today, fatal in any script that later adopts `set -e`.

## Deliberately out of scope

- **18 scripts call `apt install` without `-y`**, so an unattended `./run` blocks on prompts. That's a repo-wide sweep, not something to bury in this PR.
- **`run`'s `for script in $scripts` loop** still word-splits, so a script filename containing a space would break it. Unlike `script_dir` — which depends on where the repo is cloned — those filenames are controlled in-tree, so the risk is different in kind. Fixing it properly means `find -print0` plus `mapfile`, a bigger change than belongs here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)