### PR TITLE
fix: unattended installs and a full shell-quoting sweep

### DIFF
--- a/dev
+++ b/dev
@@ -4,7 +4,6 @@ script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 dry="0"
 
 cd "$script_dir"
-scripts=$(find ./runs -maxdepth 1 -mindepth 1 -executable -type f)
 
 while [[ $# > 0 ]]; do
     if [[ "$1" == "--dry" ]]; then

--- a/dev
+++ b/dev
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 
-script_dir="$(cd $(dirname "$BASH_SOURCE[0]}") && pwd)"
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 dry="0"
 
-cd $script_dir
+cd "$script_dir"
 scripts=$(find ./runs -maxdepth 1 -mindepth 1 -executable -type f)
 
 while [[ $# > 0 ]]; do
@@ -36,11 +36,11 @@ copy_dir() {
 	from=$1
 	to=$2
 
-	pushd $from > /dev/null
-	dirs=$(find . -mindepth 1 -maxdepth 1 -type d)
-	for dir in $dirs; do
-		execute rm -rf $to/$dir
-		execute cp -r $dir $to/$dir
+	pushd "$from" > /dev/null
+	mapfile -d '' -t dirs < <(find . -mindepth 1 -maxdepth 1 -type d -print0)
+	for dir in "${dirs[@]}"; do
+		execute rm -rf "$to/$dir"
+		execute cp -r "$dir" "$to/$dir"
 	done
 	popd > /dev/null
 }
@@ -49,15 +49,15 @@ copy_file() {
 	from=$1
 	to=$2
 
-	name=$(basename $from)
+	name=$(basename "$from")
 	
-	execute rm $to/$name
-	execute cp $from $to/$name
+	execute rm "$to/$name"
+	execute cp "$from" "$to/$name"
 }
 
 CONFIG_DIR="${XDG_CONFIG_HOME:-$HOME/.config}"
 
-copy_dir .config $CONFIG_DIR
-copy_dir .local $HOME/.local
-copy_file .bash_aliases $HOME
-copy_file .bash_profile $HOME
+copy_dir .config "$CONFIG_DIR"
+copy_dir .local "$HOME/.local"
+copy_file .bash_aliases "$HOME"
+copy_file .bash_profile "$HOME"

--- a/run
+++ b/run
@@ -5,14 +5,14 @@ filters=()
 dry="0"
 
 cd "$script_dir"
-scripts=$(find ./runs -maxdepth 1 -mindepth 1 -executable -type f)
+mapfile -d '' -t scripts < <(find ./runs -maxdepth 1 -mindepth 1 -executable -type f -print0)
 
 while [[ $# > 0 ]]; do
     if [[ "$1" == "--dry" ]]; then
         dry="1"
     elif [[ "$1" == "-l" || "$1" == "--list" ]]; then
         echo "Available tools:"
-        for script in $scripts; do
+        for script in "${scripts[@]}"; do
             basename "$script"
         done | sort
         exit 0
@@ -59,7 +59,7 @@ matches_filter() {
 
 log "run: filters=${filters[*]}"
 
-for script in $scripts; do
+for script in "${scripts[@]}"; do
     if ! matches_filter "$script"; then
         continue
     fi

--- a/runs/aws
+++ b/runs/aws
@@ -10,12 +10,12 @@ rm -rf awscliv2.zip aws/
 
 # eksctl 
 ARCH=amd64
-PLATFORM=$(uname -s)_$ARCH
+PLATFORM="$(uname -s)_$ARCH"
 
 curl -fsLO "https://github.com/eksctl-io/eksctl/releases/latest/download/eksctl_$PLATFORM.tar.gz"
-curl -fsL "https://github.com/eksctl-io/eksctl/releases/latest/download/eksctl_checksums.txt" | grep $PLATFORM | sha256sum --check
+curl -fsL "https://github.com/eksctl-io/eksctl/releases/latest/download/eksctl_checksums.txt" | grep "$PLATFORM" | sha256sum --check
 
-tar -xzf eksctl_$PLATFORM.tar.gz -C /tmp && rm eksctl_$PLATFORM.tar.gz
+tar -xzf "eksctl_$PLATFORM.tar.gz" -C /tmp && rm "eksctl_$PLATFORM.tar.gz"
 
 sudo install -m 0755 /tmp/eksctl /usr/local/bin && rm /tmp/eksctl
 

--- a/runs/bat
+++ b/runs/bat
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 
-sudo apt install bat
+sudo apt install -y bat
 
 echo "Ensure the ./dev is run to alias bat to cat"

--- a/runs/discord
+++ b/runs/discord
@@ -2,8 +2,8 @@
  
 FILENAME="discord.deb"
 
-wget -O $FILENAME https://discord.com/api/download?platform=linux&format=deb 
+wget -O "$FILENAME" "https://discord.com/api/download?platform=linux&format=deb"
 
-sudo apt install -y ./$FILENAME
+sudo apt install -y "./$FILENAME"
 
-rm $FILENAME
+rm "$FILENAME"

--- a/runs/discord
+++ b/runs/discord
@@ -4,6 +4,6 @@ FILENAME="discord.deb"
 
 wget -O $FILENAME https://discord.com/api/download?platform=linux&format=deb 
 
-sudo apt install ./$FILENAME
+sudo apt install -y ./$FILENAME
 
 rm $FILENAME

--- a/runs/docker
+++ b/runs/docker
@@ -2,7 +2,7 @@
 
 # Add Docker's official GPG key:
 sudo apt-get update
-sudo apt-get install ca-certificates curl
+sudo apt-get install -y ca-certificates curl
 sudo install -m 0755 -d /etc/apt/keyrings
 sudo curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
 sudo chmod a+r /etc/apt/keyrings/docker.asc
@@ -14,7 +14,7 @@ echo \
   sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
 sudo apt-get update
 
-sudo apt-get install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+sudo apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
 
 getent group docker >/dev/null || sudo groupadd docker
 sudo usermod -aG docker $USER

--- a/runs/docker
+++ b/runs/docker
@@ -17,6 +17,6 @@ sudo apt-get update
 sudo apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
 
 getent group docker >/dev/null || sudo groupadd docker
-sudo usermod -aG docker $USER
+sudo usermod -aG docker "$USER"
 
 echo "Run: newgrp docker"

--- a/runs/emoji-fonts
+++ b/runs/emoji-fonts
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-sudo apt install fonts-noto-color-emoji
+sudo apt install -y fonts-noto-color-emoji

--- a/runs/fd
+++ b/runs/fd
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-sudo apt install fd-find
+sudo apt install -y fd-find

--- a/runs/fzf
+++ b/runs/fzf
@@ -4,7 +4,7 @@ if [ -d /opt/fzf ]; then
   git -C /opt/fzf pull
 else
   sudo git clone https://github.com/junegunn/fzf.git /opt/fzf
-  sudo chown -R $USER:$USER /opt/fzf
+  sudo chown -R "$USER:$USER" /opt/fzf
 fi
 /opt/fzf/install
 

--- a/runs/gh
+++ b/runs/gh
@@ -2,8 +2,8 @@
 
 (type -p wget >/dev/null || (sudo apt update && sudo apt-get install wget -y)) \
 	&& sudo mkdir -p -m 755 /etc/apt/keyrings \
-        && out=$(mktemp) && wget -nv -O$out https://cli.github.com/packages/githubcli-archive-keyring.gpg \
-        && cat $out | sudo tee /etc/apt/keyrings/githubcli-archive-keyring.gpg > /dev/null \
+        && out=$(mktemp) && wget -nv -O"$out" https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+        && cat "$out" | sudo tee /etc/apt/keyrings/githubcli-archive-keyring.gpg > /dev/null \
 	&& sudo chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg \
 	&& echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
 	&& sudo apt update \

--- a/runs/gnome-extension
+++ b/runs/gnome-extension
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-sudo apt install gnome-shell-extension-manager
+sudo apt install -y gnome-shell-extension-manager

--- a/runs/go
+++ b/runs/go
@@ -2,11 +2,11 @@
 
 VERSION=1.26.2
 
-wget https://go.dev/dl/go$VERSION.linux-amd64.tar.gz
+wget "https://go.dev/dl/go$VERSION.linux-amd64.tar.gz"
 sudo rm -rf /usr/local/go
-sudo tar -C /usr/local -xzf go$VERSION.linux-amd64.tar.gz
+sudo tar -C /usr/local -xzf "go$VERSION.linux-amd64.tar.gz"
 
-rm go$VERSION.linux-amd64.tar.gz
+rm "go$VERSION.linux-amd64.tar.gz"
 
 if ! grep -q '/usr/local/go/bin' ~/.bashrc; then
     echo -e "\nPATH=\"\$PATH:/usr/local/go/bin\"" >> ~/.bashrc

--- a/runs/jq
+++ b/runs/jq
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-sudo apt install jq
+sudo apt install -y jq

--- a/runs/k8sgpt
+++ b/runs/k8sgpt
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
 
-OUTPUT_DIR=$(mktemp -d)
+OUTPUT_DIR="$(mktemp -d)"
 
-curl -L -o $OUTPUT_DIR/k8sgpt_Linux_x86_64.tar.gz \
+curl -L -o "$OUTPUT_DIR/k8sgpt_Linux_x86_64.tar.gz" \
     https://github.com/k8sgpt-ai/k8sgpt/releases/latest/download/k8sgpt_Linux_x86_64.tar.gz
 
-tar -xzf $OUTPUT_DIR/k8sgpt_Linux_x86_64.tar.gz -C $OUTPUT_DIR/
-sudo mv $OUTPUT_DIR/k8sgpt /usr/local/bin/
+tar -xzf "$OUTPUT_DIR/k8sgpt_Linux_x86_64.tar.gz" -C "$OUTPUT_DIR/"
+sudo mv "$OUTPUT_DIR/k8sgpt" /usr/local/bin/
 
-rm -rf $OUTPUT_DIR
+rm -rf "$OUTPUT_DIR"

--- a/runs/k9s
+++ b/runs/k9s
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 
 VERSION=$(curl -s https://api.github.com/repos/derailed/k9s/releases/latest | jq -r '.tag_name')
-wget https://github.com/derailed/k9s/releases/download/${VERSION}/k9s_linux_amd64.deb && sudo apt install -y ./k9s_linux_amd64.deb && rm k9s_linux_amd64.deb
+wget "https://github.com/derailed/k9s/releases/download/${VERSION}/k9s_linux_amd64.deb" && sudo apt install -y ./k9s_linux_amd64.deb && rm k9s_linux_amd64.deb

--- a/runs/k9s
+++ b/runs/k9s
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 
 VERSION=$(curl -s https://api.github.com/repos/derailed/k9s/releases/latest | jq -r '.tag_name')
-wget https://github.com/derailed/k9s/releases/download/${VERSION}/k9s_linux_amd64.deb && sudo apt install ./k9s_linux_amd64.deb && rm k9s_linux_amd64.deb
+wget https://github.com/derailed/k9s/releases/download/${VERSION}/k9s_linux_amd64.deb && sudo apt install -y ./k9s_linux_amd64.deb && rm k9s_linux_amd64.deb

--- a/runs/kubectx
+++ b/runs/kubectx
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-sudo apt install kubectx
+sudo apt install -y kubectx

--- a/runs/neovim
+++ b/runs/neovim
@@ -5,16 +5,16 @@ INSTALL_DIR=/opt/neovim
 
 sudo apt install -y ninja-build gettext cmake curl build-essential
 
-if [[ -d $INSTALL_DIR ]]; then
-    git -C $INSTALL_DIR fetch --tags --force --prune
+if [[ -d "$INSTALL_DIR" ]]; then
+    git -C "$INSTALL_DIR" fetch --tags --force --prune
 else
-    sudo git clone https://github.com/neovim/neovim.git $INSTALL_DIR
-    sudo chown -R $USER:$USER $INSTALL_DIR
+    sudo git clone https://github.com/neovim/neovim.git "$INSTALL_DIR"
+    sudo chown -R "$USER:$USER" "$INSTALL_DIR"
 fi
 
-version=$(git -C $INSTALL_DIR tag --points-at stable | grep -m1 '^v' || true)
+version=$(git -C "$INSTALL_DIR" tag --points-at stable | grep -m1 '^v' || true)
 
-if [[ -z $version ]]; then
+if [[ -z "$version" ]]; then
     echo "could not resolve a release from the stable tag" >&2
     exit 1
 fi
@@ -24,18 +24,18 @@ if command -v nvim > /dev/null; then
     installed=$(nvim --version | awk 'NR==1 {print $2; exit}')
 fi
 
-if [[ $installed == "$version" ]]; then
+if [[ "$installed" == "$version" ]]; then
     echo "neovim $version is already installed"
     exit 0
 fi
 
 echo "installing neovim $version${installed:+ (replacing $installed)}"
 
-git -C $INSTALL_DIR checkout --force $version
+git -C "$INSTALL_DIR" checkout --force "$version"
 
-if [[ -d $INSTALL_DIR/build ]]; then
-    make -C $INSTALL_DIR distclean
+if [[ -d "$INSTALL_DIR/build" ]]; then
+    make -C "$INSTALL_DIR" distclean
 fi
 
-make -C $INSTALL_DIR CMAKE_BUILD_TYPE=RelWithDebInfo
-sudo make -C $INSTALL_DIR install
+make -C "$INSTALL_DIR" CMAKE_BUILD_TYPE=RelWithDebInfo
+sudo make -C "$INSTALL_DIR" install

--- a/runs/obsidian
+++ b/runs/obsidian
@@ -2,8 +2,8 @@
 
 FILENAME="obsidian.deb"
 
-wget -O $FILENAME https://github.com/obsidianmd/obsidian-releases/releases/download/v1.10.6/obsidian_1.10.6_amd64.deb
+wget -O "$FILENAME" https://github.com/obsidianmd/obsidian-releases/releases/download/v1.10.6/obsidian_1.10.6_amd64.deb
 
-sudo apt install -y ./$FILENAME
+sudo apt install -y "./$FILENAME"
 
-rm $FILENAME
+rm "$FILENAME"

--- a/runs/obsidian
+++ b/runs/obsidian
@@ -4,6 +4,6 @@ FILENAME="obsidian.deb"
 
 wget -O $FILENAME https://github.com/obsidianmd/obsidian-releases/releases/download/v1.10.6/obsidian_1.10.6_amd64.deb
 
-sudo apt install ./$FILENAME
+sudo apt install -y ./$FILENAME
 
 rm $FILENAME

--- a/runs/ripgrep
+++ b/runs/ripgrep
@@ -1,1 +1,3 @@
-sudo apt install ripgrep
+#!/usr/bin/env bash
+
+sudo apt install -y ripgrep

--- a/runs/signal
+++ b/runs/signal
@@ -6,6 +6,6 @@ cat signal-desktop-keyring.gpg | sudo tee /usr/share/keyrings/signal-desktop-key
 wget -O signal-desktop.sources https://updates.signal.org/static/desktop/apt/signal-desktop.sources;
 cat signal-desktop.sources | sudo tee /etc/apt/sources.list.d/signal-desktop.sources > /dev/null
 
-sudo apt update && sudo apt install signal-desktop
+sudo apt update && sudo apt install -y signal-desktop
 
 rm signal-desktop-keyring.gpg signal-desktop.sources

--- a/runs/slack
+++ b/runs/slack
@@ -2,6 +2,6 @@
 
 wget -O slack.deb https://downloads.slack-edge.com/desktop-releases/linux/x64/4.46.101/slack-desktop-4.46.101-amd64.deb
 
-sudo apt install ./slack.deb
+sudo apt install -y ./slack.deb
 
 rm slack.deb

--- a/runs/spotify
+++ b/runs/spotify
@@ -4,4 +4,4 @@ curl -sS https://download.spotify.com/debian/pubkey_C85668DF69375001.gpg | sudo 
 echo "deb https://repository.spotify.com stable non-free" | sudo tee /etc/apt/sources.list.d/spotify.list
 
 sudo apt update
-sudo apt install spotify-client
+sudo apt install -y spotify-client

--- a/runs/terraform
+++ b/runs/terraform
@@ -16,5 +16,5 @@ sudo tee /etc/apt/sources.list.d/hashicorp.list
 
 sudo apt update
 
-sudo apt install terraform
+sudo apt install -y terraform
 

--- a/runs/tmux
+++ b/runs/tmux
@@ -1,13 +1,13 @@
 #!/usr/bin/env bash
 set -eu
 
-PLUGIN_DIR=$HOME/.local/share/tmux/plugins/catppuccin
+PLUGIN_DIR="$HOME/.local/share/tmux/plugins/catppuccin"
 
 sudo apt install -y tmux
 
-if [[ -d $PLUGIN_DIR ]]; then
-    git -C $PLUGIN_DIR pull --ff-only
+if [[ -d "$PLUGIN_DIR" ]]; then
+    git -C "$PLUGIN_DIR" pull --ff-only
 else
-    mkdir -p $(dirname $PLUGIN_DIR)
-    git clone https://github.com/catppuccin/tmux.git $PLUGIN_DIR
+    mkdir -p "$(dirname "$PLUGIN_DIR")"
+    git clone https://github.com/catppuccin/tmux.git "$PLUGIN_DIR"
 fi

--- a/runs/tofu
+++ b/runs/tofu
@@ -2,9 +2,9 @@
 
 FILENAME="install-opentofu.sh"
 
-curl -fsSL https://get.opentofu.org/install-opentofu.sh -o $FILENAME
-chmod +x $FILENAME
+curl -fsSL https://get.opentofu.org/install-opentofu.sh -o "$FILENAME"
+chmod +x "$FILENAME"
 
-./$FILENAME --install-method deb
+"./$FILENAME" --install-method deb
 
-rm $FILENAME
+rm "$FILENAME"

--- a/runs/unzip
+++ b/runs/unzip
@@ -1,1 +1,3 @@
-sudo apt install unzip
+#!/usr/bin/env bash
+
+sudo apt install -y unzip

--- a/runs/xclip
+++ b/runs/xclip
@@ -1,1 +1,3 @@
-sudo apt install xclip
+#!/usr/bin/env bash
+
+sudo apt install -y xclip


### PR DESCRIPTION
Started as the two leftovers from #31 and grew: the review on this PR turned up a real bug, and chasing it properly meant sweeping the rest of the repo.

Five commits, one concern each.

## `c8b7712` — `-y` on every apt call, and three missing shebangs

`./run` with no arguments walks all 39 scripts, so anything that stops to ask a question stalls the sweep. Eighteen call sites across seventeen scripts had no `-y` and would sit at `Do you want to continue? [Y/n]`. The six that already passed it are untouched, including the two in `runs/gh` that pass it trailing.

`runs/ripgrep`, `runs/unzip` and `runs/xclip` had no shebang, same as `runs/emoji-fonts` in 59db174. I missed these when I first reported on `runs/` — the check I used mangled its own output. Rechecked properly: all 39 scripts now start with `#!/usr/bin/env bash` and all are executable.

## `99faa4f` — `run` split script paths on whitespace

`scripts` was a newline-joined string expanded unquoted, so a filename containing a space became two loop iterations, neither of which existed:

```
running script: ./runs/my
./run: line 44: ./runs/my: No such file or directory
running script: tool
```

`find -print0` into `mapfile` keeps paths intact. Completes fc3dea8, which fixed `script_dir` but left the loop.

## `1a784ed` — `runs/discord` backgrounded its own download

Flagged as a nit by the review bot, but it isn't one. The URL carried an unquoted `&`, so bash split the line in two:

```
+ format=deb                                        ← separate assignment
+ wget -O discord.deb 'https://...?platform=linux'  ← backgrounded, URL truncated
```

The query string lost `&format=deb`, and because `wget` was backgrounded the following `apt install` ran against a file still downloading or absent.

## `a56b236` — full quoting sweep

Everything the earlier commits didn't reach. Most are safe today because the values contain no whitespace, but they're all the shape of the `discord` bug. Two are not cosmetic:

- **`dev` carried the same `script_dir` defect** `run` had — malformed `$BASH_SOURCE[0]}` plus an unquoted `cd`. Under a repo path containing a space, `script_dir` is empty and the later `cd $script_dir` goes to `$HOME`; `dev` then copies dotfiles out of whatever directory that turns out to be.
- **`dev`'s `copy_dir` ran `rm -rf $to/$dir` unquoted**, with `$dirs` word-split out of a `find`. A config directory with a space in its name splits into two arguments and hands `rm -rf` a path nobody intended.

`gitconfig` needed no changes — its expansions are already inside `[[ ]]` or double quotes.

## `7b62c85` — dead code in `dev`

`scripts` was assigned from a `find` over `runs/` and never read. Enumerating installer scripts is `run`'s job, which is also why `dev` had the identical `script_dir` bug — it looks to have started as a copy of `run`.

## Verification

- `bash -n` on all 42 scripts (39 in `runs/`, plus `run`, `dev`, `gitconfig`) — all parse; all executable.
- `./run -l` byte-identical before and after (40 lines).
- `./dev --dry` byte-identical across both the sweep and the dead-code removal.
- `./run --dry <filter>` still filters correctly.
- Space handling tested both directions against the pre-change version, for `run` and for the `discord` URL parse.

**Not verified:** the `apt` changes themselves. Exercising those means actually installing twenty-odd packages, so they rest on `-y` being the documented flag rather than on a test run. That's the part worth reading closely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)